### PR TITLE
Fix for 'gulp test' failure

### DIFF
--- a/src/app/backend/userlinks/userlinks_test.go
+++ b/src/app/backend/userlinks/userlinks_test.go
@@ -23,9 +23,9 @@ import (
 	"sort"
 
 	"github.com/kubernetes/dashboard/src/app/backend/api"
+	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestGetUserLinksForService(t *testing.T) {


### PR DESCRIPTION
```
can't load package: package k8s.io/client-go/pkg/api/v1: cannot find package "k8s.io/client-go/pkg/api/v1" in any of:
	/usr/local/go/src/k8s.io/client-go/pkg/api/v1 (from $GOROOT)
	/home/hari/go/src/github.com/openebs/kubernetes/dashboard/.tmp/backend/src/k8s.io/client-go/pkg/api/v1 (from $GOPATH)
	/home/hari/go/src/github.com/openebs/kubernetes/dashboard/vendor/src/k8s.io/client-go/pkg/api/v1
```

Fixed above mentioned error which is occurring while running 'gulp test' 